### PR TITLE
Download button change

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 	<section class="main">
 		<div class="container">
 			<div id="cta">
-				<a href="https://github.com/AHAAAAAAA/PokemonGo-Map/archive/master.zip" class="btn btn-primary rounded">Download!</a>
+				<a href="https://github.com/AHAAAAAAA/PokemonGo-Map/releases" class="btn btn-primary rounded">Get Started!</a>
 			</div>
 			<div class="row" id="features">
 				<div class="text-box col-md-offset-1 col-md-10">


### PR DESCRIPTION
Now points to [release page](https://github.com/AHAAAAAAA/PokemonGo-Map/releases) instead of direct download so people can see versioning/changelogs.